### PR TITLE
Configure nodejs debugging for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Run Server",
+      "skipFiles": ["<node_internals>/**"],
+      "cwd": "${workspaceFolder}",
+      "console": "externalTerminal",
+      "program": "${workspaceFolder}/src/.build/server.js",
+      "outFiles": ["${workspaceFolder}/src/.build/**/*.js"],
+      "env": {
+        "DEBUG": "*",
+        "PORT": "8080"
+      }
+    }
+  ]
+}

--- a/src/bidiServerRunner.ts
+++ b/src/bidiServerRunner.ts
@@ -30,7 +30,7 @@ export class BidiServerRunner {
     onClose: (stateObject: any) => void
   ) {
     const self = this;
-    const bidiPort: string = process.env.BIDI_PORT || '8080';
+    const bidiPort = parseInt(process.env.PORT) || 8080;
 
     const server = http.createServer(function (request, response) {
       debugInternal(new Date() + ' Received request for ' + request.url);

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./.build",
+    "sourceMap": true,
     "esModuleInterop": true,
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
Add a launch.json file and enable compiling typescript with sourcemaps.

Makes it easier to debug the bidi server when developing in VS Code.

Also fixing a bug with the `PORT` environment variable name in bidiServerRunner.ts. The readme says `PORT` but the file was using `BIDI_PORT`.